### PR TITLE
Include move history and player id in gops game state message

### DIFF
--- a/gops-clients/python/players/util/game.py
+++ b/gops-clients/python/players/util/game.py
@@ -11,6 +11,7 @@ def get_new_game_state():
         "my_bids": list(range(2, 15)),
         "their_score": 0,
         "their_bids": list(range(2, 15)),
+        "move_history": list(),
     }
 
     new_game_state = copy.deepcopy(INITIAL_GAME_STATE)
@@ -25,12 +26,13 @@ def get_next_game_state(game_state, my_bid, their_bid):
     new_state["all_bounties"].remove(new_state["active_bounty"])
     new_state["my_bids"].remove(my_bid)
     new_state["their_bids"].remove(their_bid)
-    
+    new_state["move_history"].append((new_state["active_bounty"], my_bid, their_bid))
+
     if my_bid == their_bid:
         new_state["tie_bounty"] += new_state["active_bounty"]
         new_state["active_bounty"] = 0
         return new_state
-    
+
     if my_bid > their_bid:
         new_state["my_score"] += new_state["active_bounty"] + new_state["tie_bounty"]
         new_state["active_bounty"] = new_state["tie_bounty"] = 0
@@ -39,7 +41,7 @@ def get_next_game_state(game_state, my_bid, their_bid):
         new_state["their_score"] += new_state["active_bounty"] + new_state["tie_bounty"]
         new_state["active_bounty"] = new_state["tie_bounty"] = 0
 
-    return new_state    
+    return new_state
 
 
 def swap_perspective(game_state):

--- a/gops-clients/python/pyproject.toml
+++ b/gops-clients/python/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Examples for GOPS client in Python"
 authors = ["Matthew <matthewshin2@gmail.com>"]
 readme = "README.md"
-packages = [{include = "py_gops_players"}]
+packages = [{include = "players"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/gops-clients/python/sim_games.py
+++ b/gops-clients/python/sim_games.py
@@ -71,4 +71,4 @@ if __name__ == '__main__':
         outcome = sim_game(player_one, player_two, args.verbose)
         history[outcome] += 1
 
-    print(history) 
+    print(history)

--- a/gops-engine/app/game.py
+++ b/gops-engine/app/game.py
@@ -8,6 +8,7 @@ class GameState:
     available_bids = [list(range(2, 15)), list(range(2, 15))]
     scores = [0, 0]
     tie = 0
+    move_history = list()
 
     live = False
 
@@ -41,6 +42,7 @@ class GameState:
 
     def get_state(self, player: int = 0):
         return {
+            "player_id": player,
             "active_bounty": self._active_bounty,
             "all_bounties": self.available_bounties,
             "tie_bounty": self.tie,
@@ -48,6 +50,7 @@ class GameState:
             "my_bids": self.available_bids[player],
             "their_score": self.scores[1 - player],
             "their_bids": self.available_bids[1 - player],
+            "move_history": self.move_history,
         }
 
     def get_bounty(self) -> int:
@@ -70,6 +73,8 @@ class GameState:
         self.available_bounties.remove(self._active_bounty)
         for player in range(2):
             self.available_bids[player].remove(self._active_bids[player])
+
+        self.move_history.append((self._active_bounty, self._active_bids[0], self._active_bids[1]))
 
         if self._active_bids[0] == self._active_bids[1]:
             self.tie += self._active_bounty
@@ -133,7 +138,7 @@ class GameState:
                     f"tie bounty is now {details['tie_bounty']}")
         return (f"player {details['winner']} "
                 f"won the bounty of {details['total_won']} "
-                f"with a bid of {details['winning_bid']}. " 
+                f"with a bid of {details['winning_bid']}. "
                 f"player {1-details['winner']}'s bid was {details['losing_bid']}")
 
     def deserialize(self):


### PR DESCRIPTION
Two new fields sent to clients after a round:
`move_history` - list of tuples `(bounty, player 0 bid, player 1 bid)`
`player_id` - client's player id.

These fields are needed for any client that makes moves based on opponent's previous moves. Removes the need for client to keep track of move history within a game. 